### PR TITLE
Fix: ending char is missing in broadcast

### DIFF
--- a/src/os/linux/utils.cpp
+++ b/src/os/linux/utils.cpp
@@ -13,7 +13,7 @@ std::string local_codepage_to_utf16(std::string input) {
     }
 
     size_t            in_bytes_left  = input.size();
-    size_t            out_bytes_left = in_bytes_left * 4;
+    size_t            out_bytes_left = in_bytes_left * 4 + 2;
     std::vector<char> outbuf(out_bytes_left, 0);
 
     char *in_buf  = const_cast<char *>(input.data());
@@ -24,6 +24,9 @@ std::string local_codepage_to_utf16(std::string input) {
         iconv_close(conv);
         return "";
     }
+
+    *out_ptr++ = 0;
+    *out_ptr++ = 0;
 
     iconv_close(conv);
     std::string utf16_str(outbuf.data(), out_ptr - outbuf.data());


### PR DESCRIPTION
![image](https://github.com/VeroFess/PalWorld-Server-Unoffical-Api/assets/9719003/fe9a8535-5865-4dbd-846f-8ca52a528246)
![image](https://github.com/VeroFess/PalWorld-Server-Unoffical-Api/assets/9719003/ec9e5371-2f04-487e-a27b-56a252fe8ed7)
![image](https://github.com/VeroFess/PalWorld-Server-Unoffical-Api/assets/9719003/c422075d-56fb-40d2-b4fb-cd5d03a4381b)
